### PR TITLE
[bug] Incorporate Adapter Version # at buildtime

### DIFF
--- a/main.go
+++ b/main.go
@@ -30,7 +30,7 @@ import (
 	"github.com/layer5io/meshkit/logger"
 )
 
-const (
+var (
 	serviceName = "consul-adapter"
 	version     = "none"
 	gitsha      = "none"


### PR DESCRIPTION
Signed-off-by: Michael Gfeller <mgfeller@mgfeller.net>

**Description**

The build-args main.version=$VERSION and main.gitsha=$GIT_COMMITSHA were not being set in the code.

This PR fixes #188 

**Notes for Reviewers**

**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**

- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Layer5 projects!

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR.
3. Sign your commits

By following the community's contribution conventions upfront, the review process will
be accelerated and your PR merged more quickly.
-->
