### PR TITLE
Fix pending pods due to node affinity

### DIFF
--- a/consul/install.go
+++ b/consul/install.go
@@ -122,6 +122,11 @@ func (h *Consul) applyHelmChart(del bool, version string, ns string) (string, er
 		Namespace:       ns,
 		CreateNamespace: true,
 		Action:          act,
+		OverrideValues: map[string]interface{}{
+			"server": map[string]interface{}{
+				"affinity": nil, //By default Consul does not allow more than one server pods on a single node
+			},
+		},
 		ChartLocation: mesherykube.HelmChartLocation{
 			Repository: repo,
 			Chart:      chart,


### PR DESCRIPTION
Signed-off-by: ashish <ashishjaitiwari15112000@gmail.com>

**Description**

Consul by default allows only one server pod per node, which pods on pending state in single node cluster.

**Notes for Reviewers**

**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**

- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Layer5 projects!

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR.
3. Sign your commits

By following the community's contribution conventions upfront, the review process will
be accelerated and your PR merged more quickly.
-->
