### PR TITLE
[chore] Update deprecated ioutil import

### DIFF
--- a/internal/config/releases.go
+++ b/internal/config/releases.go
@@ -3,7 +3,7 @@ package config
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	"github.com/layer5io/meshery-adapter-library/adapter"
@@ -40,7 +40,7 @@ func GetLatestReleases(releases uint) ([]*Release, error) {
 		return []*Release{}, ErrGetLatestReleases(fmt.Errorf("unexpected status code: %d", resp.StatusCode))
 	}
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return []*Release{}, ErrGetLatestReleases(err)
 	}


### PR DESCRIPTION
Signed-off-by: Antonette Caldwell <pullmana8@gmail.com>

**Description**

No open issue

**Notes for Reviewers**

A minor fix, change out the deprecated import from `io/ioutil` to `io`

**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**

- [ ] Yes, I signed my commits.

<!--
Thank you for contributing to Layer5 projects!

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR.
3. Sign your commits

By following the community's contribution conventions upfront, the review process will
be accelerated and your PR merged more quickly.
-->
