### PR TITLE
Remove the version check of golang

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,8 +29,6 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version: 1.19.x
-      - name: Set up test-env
-        run: make test-env
       - name: Run unit tests
         run: go test --short ./... -race -coverprofile=coverage.txt -covermode=atomic
       - name: Upload coverage to Codecov

--- a/Makefile
+++ b/Makefile
@@ -44,25 +44,13 @@ docker-run:
 	layer5/meshery-$(ADAPTER):$(RELEASE_CHANNEL)-latest
 
 ## Build and run Adapter locally
-run: dep-check
+run:
 	go mod tidy; \
 	DEBUG=true GOPROXY=direct GOSUMDB=off go run main.go
 
 ## Build and run Adapter locally; force component registration
 run-force-dynamic-reg: dep-check
 	FORCE_DYNAMIC_REG=true DEBUG=true GOPROXY=direct GOSUMDB=off go run main.go
-
-## Run Meshery Error utility
-error: dep-check
-	go run github.com/layer5io/meshkit/cmd/errorutil -d . analyze -i ./helpers -o ./helpers
-
-## Run Golang tests
-test: dep-check
-	export CURRENTCONTEXT="$(kubectl config current-context)" 
-	echo "current-context:" ${CURRENTCONTEXT} 
-	export KUBECONFIG="${HOME}/.kube/config"
-	echo "environment-kubeconfig:" ${KUBECONFIG}
-	GOPROXY=direct GOSUMDB=off GO111MODULE=on go test -v ./...
 
 #-----------------------------------------------------------------------------
 # Dependencies


### PR DESCRIPTION
**Description**

This PR fixes #

**Notes for Reviewers**

Manually check the if the adapter works well

```
KUBECONFIG: /home/codespace/.meshery/kubeconfig.yaml  app=consul-adapter
INFO[2023-10-12T02:18:23Z] Adaptor Listening at port: 10002              app=consul-adapter
INFO[2023-10-12T02:18:23Z] Registering static meshmodel components...    app=consul-adapter
INFO[2023-10-12T02:18:23Z] Registering latest workload components for version edge  app=consul-adapter
INFO[2023-10-12T02:18:23Z] Registering for auth.consul.hashicorp.com_trafficpermissions.yaml  app=consul-adapter
INFO[2023-10-12T02:18:24Z] auth.consul.hashicorp.com_trafficpermissions.yaml registered  app=consul-adapter
INFO[2023-10-12T02:18:24Z] Registering for consul.hashicorp.com_controlplanerequestlimits.yaml  app=consul-adapter
INFO[2023-10-12T02:18:24Z] consul.hashicorp.com_controlplanerequestlimits.yaml registered  app=consul-adapter
INFO[2023-10-12T02:18:24Z] Registering for consul.hashicorp.com_exportedservices.yaml  app=consul-adapter
INFO[2023-10-12T02:18:24Z] consul.hashicorp.com_exportedservices.yaml registered  app=consul-adapter
INFO[2023-10-12T02:18:24Z] Registering for consul.hashicorp.com_gatewayclassconfigs.yaml  app=consul-adapter
INFO[2023-10-12T02:18:25Z] consul.hashicorp.com_gatewayclassconfigs.yaml registered  app=consul-adapter
INFO[2023-10-12T02:18:25Z] Registering for consul.hashicorp.com_gatewaypolicies.yaml  app=consul-adapter
INFO[2023-10-12T02:18:25Z] consul.hashicorp.com_gatewaypolicies.yaml registered  app=consul-adapter
INFO[2023-10-12T02:18:25Z] Registering for consul.hashicorp.com_ingressgateways.yaml  app=consul-adapter
INFO[2023-10-12T02:18:25Z] consul.hashicorp.com_ingressgateways.yaml registered  app=consul-adapter
INFO[2023-10-12T02:18:25Z] Registering for consul.hashicorp.com_jwtproviders.yaml  app=consul-adapter
INFO[2023-10-12T02:18:25Z] consul.hashicorp.com_jwtproviders.yaml registered  app=consul-adapter
INFO[2023-10-12T02:18:25Z] Registering for consul.hashicorp.com_meshes.yaml  app=consul-adapter
INFO[2023-10-12T02:18:26Z] consul.hashicorp.com_meshes.yaml registered   app=consul-adapter
INFO[2023-10-12T02:18:26Z] Registering for consul.hashicorp.com_meshservices.yaml  app=consul-adapter
INFO[2023-10-12T02:18:26Z] consul.hashicorp.com_meshservices.yaml registered  app=consul-adapter
INFO[2023-10-12T02:18:26Z] Registering for consul.hashicorp.com_peeringacceptors.yaml  app=consul-adapter
INFO[2023-10-12T02:18:26Z] consul.hashicorp.com_peeringacceptors.yaml registered  app=consul-adapter
INFO[2023-10-12T02:18:26Z] Registering for consul.hashicorp.com_peeringdialers.yaml  app=consul-adapter
INFO[2023-10-12T02:18:27Z] consul.hashicorp.com_peeringdialers.yaml registered  app=consul-adapter
INFO[2023-10-12T02:18:27Z] Registering for consul.hashicorp.com_proxydefaults.yaml  app=consul-adapter
INFO[2023-10-12T02:18:27Z] consul.hashicorp.com_proxydefaults.yaml registered  app=consul-adapter
INFO[2023-10-12T02:18:27Z] Registering for consul.hashicorp.com_routeauthfilters.yaml  app=consul-adapter
INFO[2023-10-12T02:18:27Z] consul.hashicorp.com_routeauthfilters.yaml registered  app=consul-adapter
INFO[2023-10-12T02:18:27Z] Registering for consul.hashicorp.com_routeretryfilters.yaml  app=consul-adapter
INFO[2023-10-12T02:18:27Z] consul.hashicorp.com_routeretryfilters.yaml registered  app=consul-adapter
INFO[2023-10-12T02:18:27Z] Registering for consul.hashicorp.com_routetimeoutfilters.yaml  app=consul-adapter
INFO[2023-10-12T02:18:28Z] consul.hashicorp.com_routetimeoutfilters.yaml registered  app=consul-adapter
INFO[2023-10-12T02:18:28Z] Registering for consul.hashicorp.com_samenessgroups.yaml  app=consul-adapter
INFO[2023-10-12T02:18:28Z] consul.hashicorp.com_samenessgroups.yaml registered  app=consul-adapter
INFO[2023-10-12T02:18:28Z] Registering for consul.hashicorp.com_servicedefaults.yaml  app=consul-adapter
INFO[2023-10-12T02:18:28Z] consul.hashicorp.com_servicedefaults.yaml registered  app=consul-adapter
INFO[2023-10-12T02:18:28Z] Registering for consul.hashicorp.com_serviceintentions.yaml  app=consul-adapter
INFO[2023-10-12T02:18:29Z] consul.hashicorp.com_serviceintentions.yaml registered  app=consul-adapter
INFO[2023-10-12T02:18:29Z] Registering for consul.hashicorp.com_serviceresolvers.yaml  app=consul-adapter
INFO[2023-10-12T02:18:29Z] consul.hashicorp.com_serviceresolvers.yaml registered  app=consul-adapter
INFO[2023-10-12T02:18:29Z] Registering for consul.hashicorp.com_servicerouters.yaml  app=consul-adapter
INFO[2023-10-12T02:18:29Z] consul.hashicorp.com_servicerouters.yaml registered  app=consul-adapter
INFO[2023-10-12T02:18:29Z] Registering for consul.hashicorp.com_servicesplitters.yaml  app=consul-adapter
INFO[2023-10-12T02:18:29Z] consul.hashicorp.com_servicesplitters.yaml registered  app=consul-adapter
INFO[2023-10-12T02:18:29Z] Registering for consul.hashicorp.com_terminatinggateways.yaml  app=consul-adapter
INFO[2023-10-12T02:18:30Z] consul.hashicorp.com_terminatinggateways.yaml registered  app=consul-adapter
INFO[2023-10-12T02:18:30Z] Component creation completed for version v1.3.0-rc1  app=consul-adapter
INFO[2023-10-12T02:18:30Z] Registering workloads with Meshery Server for version v1.3.0-rc1  app=consul-adapter
```


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**

- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Layer5 projects!

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR.
3. Sign your commits

By following the community's contribution conventions upfront, the review process will
be accelerated and your PR merged more quickly.
-->
